### PR TITLE
Encode separately

### DIFF
--- a/bitcode.c
+++ b/bitcode.c
@@ -88,6 +88,8 @@ void flushBits (int fd)
 {
     if (nExtra != 0)
         fdputc(extraBits << (CHAR_BIT - nExtra), fd);
+    nExtra = 0;
+    extraBits = 0;
 }
 
 
@@ -106,7 +108,11 @@ int getBits (int nBits, int fd)
     // Read enough new bytes to have at least nBits bits to extract code
     while (nExtra < nBits) {
         if ((c = fdgetc(fd)) == EOF)
+        {
+            extraBits = 0;
+            nExtra = 0; // reset for next file
             return EOF;                         // Return EOF on end-of-file
+        }
         nExtra += CHAR_BIT;
         extra = (extra << CHAR_BIT) | c;
     }

--- a/encrypt.h
+++ b/encrypt.h
@@ -26,14 +26,14 @@
  *
  * Flags may be separated or condensed, so -pq and -pv -q are both valid
  * 
- * In series mode, the following filenames must be unused
- * (files will be overwritten), where ArchiveName is the command line argument:
- * ArchiveName.far
- * ArchiveName.lzw
- * ArchiveName
- * On decrypt, all files to extract will be overwritten,
- * and ArchiveName is required to exist and be readable
- * In parallel mode, only ArchiveName itself will be used.
+ * The following filenames must be unused
+ * (files will be overwritten if writable),
+ * where ArchiveName is the command line argument,
+ * and File is any command line argument after the ArchiveName:
+ * ArchiveName.far (only in series mode)
+ * ArchiveName (only in encode, in decode this file is needed)
+ * File.lzw
+ * File (only in decode, in encode this file is needed)
  *
  * ArchiveName may not begin with a hyphen, but it may be any writable path
  * Therefore ./-name is a valid workaround
@@ -43,17 +43,15 @@
  * Note that every file is prefixed by some metadata
  * Request password string from stdin
  * Create ArchiveName.far, a single file containing listed files and directories
- *     metadata: 0 byte
- * Create ArchiveName.lzw by performing LZW compression on ArchiveName.far
- *     metadata: nonzero byte
- * If ArchiveName.lzw is bigger, ignore it and use ArchiveName.far instead
- *     In decryption, run lzw decompression iff the first byte is nonzero
+ * With data from files compressed using LZW compression
+ *     metadata before each file: 0 byte if uncompressed, nonzero byte otherwise
  * Create ArchiveName by running RSA encryption
- *     metadata: hash of password string using the SHA1 hash function
+ *     metadata: hash of password string and salt using the SHA1 hash function
  *
- * All RSA keys are hard-coded into the source code of encrypt, so to maintain
+ * All RSA keys are hard-coded into the source code of rsa.c, so to maintain
  * security you should compile, then encrypt the source file keys.h
- * If portability isn't a problem, you can remove keys.h after compiling
+ * If portability isn't a problem, you can remove keys.h after compiling,
+ * and run make clean to remove rsa.o
  */
 
 #ifndef ENCRYPT_H

--- a/far.c
+++ b/far.c
@@ -184,7 +184,7 @@ void extract(int archive)
                 if (fclose(file)) SYS_ERROR("fclose");
                 if (chmod(nodeName, mode)) SYS_ERROR("chmod");
 #if MAC
-                if (chflags(nodeName, flags))SYS_ERROR("chflags");
+                if (chflags(nodeName, flags)) SYS_ERROR("chflags");
                 if (utimes(nodeName, times)) SYS_ERROR("utimes");
 #endif
             }

--- a/far.c
+++ b/far.c
@@ -9,7 +9,9 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <fcntl.h>
 #include "bitcode.h"
+#include "lzw.h"
 
 /**
  * Given archive open for writing and path to inode, copy node into archive
@@ -22,6 +24,7 @@ void archiveNode(int archive, char* node)
     PROGRESS("Archiving node %s", node);
     struct stat nodeData;
     if (lstat(node, &nodeData)) SYS_ERR_DONE("lstat");
+
     mode_t mode = nodeData.st_mode;
 #if MAC
     // store these so they can be restored
@@ -89,15 +92,49 @@ void archiveNode(int archive, char* node)
         off_t size = nodeData.st_size;
         if (write(archive, &size, sizeof(size))<sizeof(size)) SYS_DIE("write");
         // regular file
-        FILE* file = fopen(node, "r");
-        if (!file) SYS_ERR_DONE("fopen");
-        int c;
-        while ((c = fgetc(file)) != EOF)
+        int file = open(node, O_RDONLY);
+        if (file < 0) SYS_ERR_DONE("open");
+
+        char* nodeLZW = calloc(nodeLen + 5, 1);
+        sprintf(nodeLZW, "%s.lzw", node);
+        int encoded = open(nodeLZW, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+        if (encoded < 0) SYS_ERR_DONE("open lzw");
+
+        // encode this file
+        PROGRESS("Encoding %s to %s", node, nodeLZW);
+        bool didEncode = encode(file, encoded);
+        if (close(encoded)) SYS_ERROR("close");
+        if (close(file)) SYS_ERROR("close");
+
+        if (didEncode)
         {
-            fdputc(c, archive);
+            // write from nodeLZW to archive
+            FILE* lzw = fopen(nodeLZW, "r");
+            if (!lzw) SYS_DIE("fopen");
+            int c;
+            while ((c = fgetc(lzw)) != EOF)
+            {
+                fdputc(c, archive);
+            }
+            if (fclose(lzw)) SYS_ERROR("close");
         }
-        if (fclose(file)) SYS_ERR_DONE("fclose");
-        if (removeOriginal && remove(node)) SYS_ERR_DONE("remove");
+        else
+        {
+            fdputc(0, archive);
+            // copy from node to archive
+            FILE* f = fopen(node, "r");
+            if (!f) SYS_DIE("open");
+            int c;
+            while ((c = fgetc(f)) != EOF)
+            {
+                fdputc(c, archive);
+            }
+            if (fclose(f)) SYS_ERROR("close");
+        }
+        if (remove(nodeLZW)) SYS_ERROR("remove");
+        free(nodeLZW);
+        
+        if (removeOriginal && remove(node)) SYS_ERROR("remove");
     }
 }
 
@@ -108,12 +145,7 @@ void archive(int archive, int nodeC, char** nodes)
 {
     STATUS("%s", "Archiving");
 
-    fdputc(0, archive);
-
-    for (int i = 0; i < nodeC; i++)
-    {
-        archiveNode(archive, nodes[i]);
-    }
+    for (int i = 0; i < nodeC; i++) archiveNode(archive, nodes[i]);
 
     PROGRESS("%s", "Archive complete");
 }
@@ -121,9 +153,6 @@ void archive(int archive, int nodeC, char** nodes)
 void extract(int archive)
 {
     STATUS("%s", "Extracting");
-
-    int prefixByte = fdgetc(archive);
-    if (prefixByte != 0) DIE("Prefix byte nonzero: %d", prefixByte);
 
     int nodeNameLen;
     int lenSize = sizeof(nodeNameLen);
@@ -173,12 +202,10 @@ void extract(int archive)
                 DIE("%s", "Unable to read size");
             FILE* file = fopen(nodeName, "w");
             if (!file) SYS_ERROR("fopen"); // permissions error
-            for (off_t i=0; i<size; i++)
-            {
-                int c = fdgetc(archive);
-                if (c == EOF) DIE("%s", "File ended unexpectedly");
-                if (file) fputc(c, file);
-            }
+
+            // decode into the file
+            decode(archive, fileno(file), size);
+
             if (file)
             {
                 if (fclose(file)) SYS_ERROR("fclose");

--- a/far.h
+++ b/far.h
@@ -6,6 +6,7 @@
  */
 
 // input file descriptor for writing to archive
+// archives each node into the file in encoded format
 void archive(int archive, int nodeC, char** nodes);
 
 // input file descriptor for reading from archive

--- a/lzw.h
+++ b/lzw.h
@@ -9,16 +9,15 @@
 
 #define UNCOMPRESSABLE 5
 
-// input must begin with a zero bit
 // output will begin with a one bit
 // does not increase size of file
-// if this isn't possible, exit(UNCOMPRESSABLE) is called
+// returns whether this is possible.
 // inFile is file descriptor open for reading.
 // outFile is file descriptor open for writing.
-void encode(int inFile, int outFile);
+bool encode(int inFile, int outFile);
 
 // exact inverse of encode
 // inFile is file descriptor for reading, outFile is for writing
-void decode(int inFile, int outFile);
+void decode(int inFile, int outFile, int bytesToWrite);
 
 #endif

--- a/rsa.c
+++ b/rsa.c
@@ -304,6 +304,7 @@ void encryptRSA(char* password, int inFile, int outFile)
 // m = c^d mod n will convert ciphertext c into message m
 void decryptRSA(char* password, int inFile, int outFile)
 {
+    STATUS("%s", "Decrypting");
     /*
     PROGRESS("Decrypting from %s to %s", inputName, outputName);
     fflush(stdout);


### PR DESCRIPTION
With the assumption that different files won't have much redundancy between them, extract() now encodes each file to a .lzw file for greater overall compression. This increases dependencies since the .lzw file must be available on encode, and it decreases parallelization. I used to do encode and encrypt at the same time, but now each encode must complete (for the short-circuiting to work) before encrypt can begin. Note: decrypt (the slow one) can still happen completely in parallel with decode.
